### PR TITLE
certificate addition for requests + interface changes for notifyLogin

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -183,7 +183,7 @@ export class Accounts {
      * 
      * @see http://developers.gigya.com/display/GD/accounts.notifyLogin+REST
      */
-    public notifyLogin(params: AccountsNotifyLoginParamsSiteUID | AccountsNotifyLoginParamsProviderSessions) {
+    public notifyLogin(params: AccountsNotifyLoginParams | AccountsNotifyLoginParamsProviderSessions) {
         return this.gigya.request<Account & SessionInfo>('accounts.notifyLogin', params);
     }
 
@@ -331,15 +331,14 @@ export interface AccountsLogoutParams {
 }
 
 export interface AccountsNotifyLoginParams {
-    siteUID?: string;
+    siteUID: string;
     providerSessions?: { [key: string]: any; };
     cid?: string;
     targetEnv?: TargetEnv;
     regSource?: string;
+    sessionExpiration?: number;
 }
-export interface AccountsNotifyLoginParamsSiteUID extends AccountsNotifyLoginParams {
-    siteUID: string;
-}
+
 export interface AccountsNotifyLoginParamsProviderSessions extends AccountsNotifyLoginParams {
     providerSessions: { [key: string]: any; };
 }

--- a/lib/gigya.ts
+++ b/lib/gigya.ts
@@ -1,3 +1,4 @@
+import fs = require('fs');
 import _ = require('lodash');
 import request = require('request');
 import sleep from './helpers/sleep';
@@ -13,6 +14,8 @@ import GigyaResponse from './interfaces/gigya-response';
 import ErrorCode from './interfaces/error-code';
 
 export class Gigya {
+    private gigyaCertificatePath:string = "/assets/certificates/gigyaCA.cer";
+    private gigyaCertificate:string;
     protected static readonly _RATE_LIMIT_SLEEP = 2000;
     protected APIKey: string;
     protected dataCenter: string;
@@ -49,8 +52,12 @@ export class Gigya {
     }
 
     protected http<R>(uri: string, params: any): Promise<GigyaResponse & R> {
+        if(!this.gigyaCertificate) {
+            this.gigyaCertificate = fs.readFileSync(`${__dirname} ${this.gigyaCertificatePath}`, 'utf-8');
+        }
         return new Promise<GigyaResponse & R>((resolve, reject) => {
             request.post(uri, {
+                ca: this.gigyaCertificate,
                 method: 'post',
                 form: params
             }, (error, response, body) => {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/lodash": "^4.14.41",
     "@types/node": "0.0.2",
     "@types/request": "0.0.36",
+    "file-system": "^2.2.2",
     "lodash": "^4.17.2",
     "request": "^2.79.0"
   },


### PR DESCRIPTION
I didn't understand why there's a "AccountsNotifyLoginParamsSiteUID"
Each call to notifyLogin has to have siteUID which mandatory.
I just added the sessionExpiration as optional.
I added an "if" for the certificate read to prevent multiple IO in case there's a use of the same object