### PR TITLE
Fixed obvious copy/paste error for ds.store

### DIFF
--- a/lib/ds.ts
+++ b/lib/ds.ts
@@ -60,7 +60,7 @@ export class DS {
      * @see http://developers.gigya.com/display/GD/ds.store+REST
      */
     public store(params: BaseParams & DSStoreParams) {
-        return this.gigya.request<DSStoreResponse>('ds.setSchema', params);
+        return this.gigya.request<DSStoreResponse>('ds.store', params);
     }
 }
 


### PR DESCRIPTION
The change is fairly self-explanatory. Tested the .store method after the change and it works fine ...