### PR TITLE
Feat fidm.oidc.op.getMetadata support

### DIFF
--- a/lib/fidm.oidc.op.ts
+++ b/lib/fidm.oidc.op.ts
@@ -11,7 +11,7 @@ export class FidmOidcOp {
 
     /**
      * This API deletes an existing OP configuration.
-     * 
+     *
      * @see http://developers.gigya.com/display/GD/fidm.oidc.op.clearConfig+REST
      */
     public clearConfig(params: BaseParams & any) {
@@ -20,7 +20,7 @@ export class FidmOidcOp {
 
     /**
      * This API registers and configures a new RP for the OP.
-     * 
+     *
      * @see http://developers.gigya.com/display/GD/fidm.oidc.op.createRP+REST
      */
     public createRP(params: BaseParams & any) {
@@ -29,7 +29,7 @@ export class FidmOidcOp {
 
     /**
      * This API deletes an existing OP configuration.
-     * 
+     *
      * @see http://developers.gigya.com/display/GD/fidm.oidc.op.delRP+REST
      */
     public delRP(params: BaseParams & any) {
@@ -38,7 +38,7 @@ export class FidmOidcOp {
 
     /**
      * This API retrieves the site OP configuration relevant for all clients/relying-parties of the site.
-     * 
+     *
      * @see http://developers.gigya.com/display/GD/fidm.oidc.op.getConfig+REST
      */
     public getConfig(params: BaseParams & any) {
@@ -46,8 +46,17 @@ export class FidmOidcOp {
     }
 
     /**
+    * This API retrieves the site OP metadata.
+    *
+    * @see http://developers.gigya.com/display/GD/fidm.oidc.op.getMetadata+REST
+    */
+    public getMetadata(params: BaseParams & any) {
+        return this.gigya.request('fidm.oidc.op.getMetadata', params);
+    }
+
+    /**
      * This API returns the configuration data for a specified RP.
-     * 
+     *
      * @see http://developers.gigya.com/display/GD/fidm.oidc.op.getRP+REST
      */
     public getRP(params: BaseParams & any) {
@@ -56,7 +65,7 @@ export class FidmOidcOp {
 
     /**
      * This API Returns all the currently registered RPs for the OP.
-     * 
+     *
      * @see http://developers.gigya.com/display/GD/fidm.oidc.op.getRPs+REST
      */
     public getRPs(params: BaseParams & any) {
@@ -65,7 +74,7 @@ export class FidmOidcOp {
 
     /**
      * This API initiates the OP  functionality for your site. The configuration of the OP is relevant to all of the site's RPs.
-     * 
+     *
      * @see http://developers.gigya.com/display/GD/fidm.oidc.op.setConfig+REST
      */
     public setConfig(params: BaseParams & any) {
@@ -74,7 +83,7 @@ export class FidmOidcOp {
 
     /**
      * This API updates the configuration of an existing RP  configured on the OP.
-     * 
+     *
      * @see http://developers.gigya.com/display/GD/fidm.oidc.op.updateRP+REST
      */
     public updateRP(params: BaseParams & any) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "gigya"
   ],
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": {
     "name": "Scott Hovestadt",
     "email": "scott.hovestadt@gmail.com"


### PR DESCRIPTION
## Issue #52 

## What is this about?

New endpoint under fidm.oidc.op namespace

## What does it do?

Allow developers to pull the OIDC OP Metadata which contains authorize, token, userinfo, introspect endpoints and JSON web keys.