### PR TITLE
chore: bump typescript target to ES2015

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "outDir": "dist",
         "declaration": true,
         "module": "commonjs",
-        "target": "es5",
+        "target": "ES2015",
         "lib": ["es6"],
         "noImplicitAny": true,
         "strictNullChecks": true,


### PR DESCRIPTION
When the target is ES5, typescript emits class inheritance code that is [incompatible with instanceof checks](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work) in some cases.

A consequence of targeting ES5 is that library consumers cannot use `instanceof` type narrowing on errors thrown by the library:

```ts
try {
  const res = await gigya.accounts.getAccountInfo({UID});
} catch (err) {
  if (err instanceof GigyaError) {
    // unreachable when target is ES5
  } 
}
```

Bumping the target to ES2015 resolves this issue.